### PR TITLE
Support IDA 9.0 and jump from decompile

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,29 @@ PacXplorer looks for the original pointer tags, which will have either been pres
 
 At runtime, a simple matching of these two mappings is performed.
 
+## External usage
+If you want to query PAC Xrefs from your own plugin, you can use the following code:
+```py
+from netnode import Netnode
+n = Netnode("$ pacxplorer_io")
+
+# From call site to virtual function 
+n["input"] = 0x1234 # address of movk
+idaapi.load_and_run_plugin("pacxplorer", 5)
+r = n.get("output")
+if r is not None:
+    # List of dicts with keys: xref_to, vtable_addr, vtable_entry_addr, offset, pac
+    res = json.loads(r)
+
+# From virtual function to call site
+n["input"] = 0x1234 # address of virtual functions
+idaapi.load_and_run_plugin("pacxplorer", 6)
+r = n.get("output")
+if r is not None:
+    # Pairs of possible call site, and pac code.
+    res = json.loads(r)
+```
+
  ## Q&A
 **Q: Why are there several virtual methods in the XREFs window?**  
 **A:** This is the *inherent ambiguity* which is an intrinsic limitation of this method.  

--- a/pacxplorer.py
+++ b/pacxplorer.py
@@ -1031,7 +1031,6 @@ def find_call_from_ea(cfunc, item_ea):
         item_ea = next_ea
         insn = idautils.DecodeInstruction(item_ea)
     if insn is None:
-        print(f"Got none for ea {item_ea=}")
         return None
     return item_ea
 

--- a/pacxplorer.py
+++ b/pacxplorer.py
@@ -252,13 +252,13 @@ class VtableAnalyzer(object):
 
     # Based on https://github.com/Synacktiv-contrib/kernelcache-laundering/blob/master/ios12_kernel_cache_helper.py
     @staticmethod
-    def get_pac(decorated_addr):
+    def get_pac(decorated_addr, pac_offset):
         """Return MOVK pac code from decorated pointer"""
         if decorated_addr & 0x4000000000000000 != 0:
             return None
         if decorated_addr & 0x8000000000000000 == 0:
             return None
-        return (decorated_addr >> 32) & 0xFFFF
+        return (decorated_addr >> pac_offset) & 0xFFFF
 
     @staticmethod
     def _patched_bytes_in_idb():
@@ -312,6 +312,7 @@ class VtableAnalyzer(object):
             <offset of this> --> another base class
             < etc >
             """
+            pac_offset = 34 if 'DYLD cache' in idaapi.get_file_type_name() else 32
 
             for ea, vtable_symbol in iteritems(self.vtable_eas):
 
@@ -344,7 +345,7 @@ class VtableAnalyzer(object):
                             break
 
                         # this is expected to always succeed
-                        pac = self.get_pac(orig_qword)
+                        pac = self.get_pac(orig_qword, pac_offset)
                         if pac is not None:
                             xref_to = idaapi.get_qword(ea + offset)
 

--- a/pacxplorer.py
+++ b/pacxplorer.py
@@ -15,20 +15,22 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+
 import json
 import mmap
-import idaapi
-import idc
-import idautils
-from netnode import Netnode
-from idaapi import Choose
-import ida_kernwin
-import ida_hexrays
-from collections import namedtuple
-from functools import wraps, partial
 import os
 import struct
 import sys
+from collections import namedtuple
+from functools import partial, wraps
+
+import ida_hexrays
+import ida_kernwin
+import idaapi
+import idautils
+import idc
+from idaapi import Choose
+from netnode import Netnode
 
 PYTHON3 = sys.version_info.major == 3
 if PYTHON3:
@@ -252,9 +254,9 @@ class VtableAnalyzer(object):
 
     # Based on https://github.com/Synacktiv-contrib/kernelcache-laundering/blob/master/ios12_kernel_cache_helper.py
     @staticmethod
-    def get_pac(decorated_addr, pac_offset):
+    def get_pac(decorated_addr, pac_offset, has_bind_bit=True):
         """Return MOVK pac code from decorated pointer"""
-        if decorated_addr & 0x4000000000000000 != 0:
+        if has_bind_bit and decorated_addr & 0x4000000000000000 != 0:
             return None
         if decorated_addr & 0x8000000000000000 == 0:
             return None
@@ -312,7 +314,14 @@ class VtableAnalyzer(object):
             <offset of this> --> another base class
             < etc >
             """
-            pac_offset = 32 if 'kernelcache' in idaapi.get_file_type_name() else 36
+            file_type = idaapi.get_file_type_name().lower()
+            if 'dyld' in file_type and 'cache' in file_type:
+                # DYLD_CHAINED_PTR_ARM64E_SHARED_CACHE: diversity at bits 34..49
+                pac_offset = 34
+            else:
+                # DYLD_CHAINED_PTR_ARM64E[_KERNEL]: diversity at bits 32..47
+                pac_offset = 32
+
 
             for ea, vtable_symbol in iteritems(self.vtable_eas):
 
@@ -345,7 +354,7 @@ class VtableAnalyzer(object):
                             break
 
                         # this is expected to always succeed
-                        pac = self.get_pac(orig_qword, pac_offset)
+                        pac = self.get_pac(orig_qword, pac_offset, has_bind_bit=pac_offset == 32)
                         if pac is not None:
                             xref_to = idaapi.get_qword(ea + offset)
 

--- a/pacxplorer.py
+++ b/pacxplorer.py
@@ -312,7 +312,7 @@ class VtableAnalyzer(object):
             <offset of this> --> another base class
             < etc >
             """
-            pac_offset = 32 if 'kernelcache' in idaapi.get_file_type_name() else 34
+            pac_offset = 32 if 'kernelcache' in idaapi.get_file_type_name() else 36
 
             for ea, vtable_symbol in iteritems(self.vtable_eas):
 

--- a/pacxplorer.py
+++ b/pacxplorer.py
@@ -312,7 +312,7 @@ class VtableAnalyzer(object):
             <offset of this> --> another base class
             < etc >
             """
-            pac_offset = 34 if 'DYLD cache' in idaapi.get_file_type_name() else 32
+            pac_offset = 32 if 'kernelcache' in idaapi.get_file_type_name() else 34
 
             for ea, vtable_symbol in iteritems(self.vtable_eas):
 


### PR DESCRIPTION
- IDA 9.0 support: IDA can now recognize the pac pattern, so the register name changed.
- Add support for jumping from decompiled view to xrefs of the function
- Add support for calling the plugin to extract pac xrefs